### PR TITLE
Change Nginx server to listen on port 8080

### DIFF
--- a/pfm-full-stack-frontend/nginx.conf
+++ b/pfm-full-stack-frontend/nginx.conf
@@ -1,5 +1,5 @@
 server {
-  listen 80;
+  listen 8080;
 
   location / {
     root   /usr/share/nginx/html;


### PR DESCRIPTION
This pull request makes a small configuration change to the Nginx server. The server is now configured to listen on port 8080 instead of port 80.