### PR TITLE
Remove port specification from deployment config

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -38,5 +38,6 @@ jobs:
             --image gcr.io/${{ secrets.GCP_PROJECT_ID }}/pfm-full-stack-frontend:latest \
             --platform managed \
             --region southamerica-east1 \
+            --port 80 \
             --allow-unauthenticated \
             --quiet

--- a/pfm-full-stack-frontend/nginx.conf
+++ b/pfm-full-stack-frontend/nginx.conf
@@ -1,5 +1,5 @@
 server {
-  listen 8080;
+  listen 80;
 
   location / {
     root   /usr/share/nginx/html;


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow for the frontend application. It explicitly sets the port to 80 when deploying to Google Cloud Run, which clarifies which port the service should listen on.

- Deployment workflow update:
  * [`.github/workflows/deploy-frontend.yml`](diffhunk://#diff-64f2f74f4d05399d57c48809ad9ec9bc55550bd51d5faf574866753ea4d781dbR41): Added the `--port 80` flag to the Cloud Run deploy command to explicitly specify the service port.